### PR TITLE
Organize API class generation with interface/definitive subfolders

### DIFF
--- a/CrudForms/Regras/ApiClasses/NamesHandler.cs
+++ b/CrudForms/Regras/ApiClasses/NamesHandler.cs
@@ -82,12 +82,16 @@ namespace Regras.ApiClasses
                     retorno = Util.Global.app_classes_entities_directory;
                     break;
                 case NamesHandler.ClasseType.InterfaceRepository:
+                    retorno = Util.Global.app_classes_repository_interface_directory;
+                    break;
                 case NamesHandler.ClasseType.Repository:
-                    retorno = Util.Global.app_classes_repository_directory;
+                    retorno = Util.Global.app_classes_repository_definitive_directory;
                     break;
                 case NamesHandler.ClasseType.InterfaceService:
+                    retorno = Util.Global.app_classes_services_interfaces_directory;
+                    break;
                 case NamesHandler.ClasseType.Service:
-                    retorno = Util.Global.app_classes_services_directory;
+                    retorno = Util.Global.app_classes_services_definitive_directory;
                     break;
                 case NamesHandler.ClasseType.Controller:
                     retorno = Util.Global.app_classes_controller_directory;

--- a/Utils/Util/CL_Files.cs
+++ b/Utils/Util/CL_Files.cs
@@ -149,8 +149,16 @@ namespace Util
                 Directory.Delete(Global.app_classes_viewModel_directory);
             if (!Directory.Exists(Global.app_classes_repository_directory))
                 Directory.Delete(Global.app_classes_repository_directory);
+            if (!Directory.Exists(Global.app_classes_repository_interface_directory))
+                Directory.Delete(Global.app_classes_repository_interface_directory);
+            if (!Directory.Exists(Global.app_classes_repository_definitive_directory))
+                Directory.Delete(Global.app_classes_repository_definitive_directory);
             if (!Directory.Exists(Global.app_classes_services_directory))
                 Directory.Delete(Global.app_classes_services_directory);
+            if (!Directory.Exists(Global.app_classes_services_interfaces_directory))
+                Directory.Delete(Global.app_classes_services_interfaces_directory);
+            if (!Directory.Exists(Global.app_classes_services_definitive_directory))
+                Directory.Delete(Global.app_classes_services_definitive_directory);
             if (!Directory.Exists(Global.app_classes_controller_directory))
                 Directory.Delete(Global.app_classes_controller_directory);
             if (!Directory.Exists(Global.app_classes_profile_dto_directory))
@@ -192,8 +200,16 @@ namespace Util
                 Directory.CreateDirectory(Global.app_classes_viewModel_directory);
             if (!Directory.Exists(Global.app_classes_repository_directory))
                 Directory.CreateDirectory(Global.app_classes_repository_directory);
+            if (!Directory.Exists(Global.app_classes_repository_interface_directory))
+                Directory.CreateDirectory(Global.app_classes_repository_interface_directory);
+            if (!Directory.Exists(Global.app_classes_repository_definitive_directory))
+                Directory.CreateDirectory(Global.app_classes_repository_definitive_directory);
             if (!Directory.Exists(Global.app_classes_services_directory))
                 Directory.CreateDirectory(Global.app_classes_services_directory);
+            if (!Directory.Exists(Global.app_classes_services_interfaces_directory))
+                Directory.CreateDirectory(Global.app_classes_services_interfaces_directory);
+            if (!Directory.Exists(Global.app_classes_services_definitive_directory))
+                Directory.CreateDirectory(Global.app_classes_services_definitive_directory);
             if (!Directory.Exists(Global.app_classes_controller_directory))
                 Directory.CreateDirectory(Global.app_classes_controller_directory);
             if (!Directory.Exists(Global.app_classes_profile_dto_directory))

--- a/Utils/Util/Global.cs
+++ b/Utils/Util/Global.cs
@@ -46,7 +46,11 @@ namespace Util
         public static string app_classes_dto_directory = app_classes_directory + "DTO\\";
         public static string app_classes_viewModel_directory = app_classes_directory + "ViewModel\\";
         public static string app_classes_repository_directory = app_classes_directory + "Repository\\";
+        public static string app_classes_repository_interface_directory = app_classes_repository_directory + "Interface\\";
+        public static string app_classes_repository_definitive_directory = app_classes_repository_directory + "Definitive\\";
         public static string app_classes_services_directory = app_classes_directory + "Services\\";
+        public static string app_classes_services_interfaces_directory = app_classes_services_directory + "Interfaces\\";
+        public static string app_classes_services_definitive_directory = app_classes_services_directory + "Definitive\\";
         public static string app_classes_controller_directory = app_classes_directory + "Controller\\";
         public static string app_classes_profile_dto_directory = app_classes_directory + "ProfilesDTO\\";
         public static string app_classes_profile_viewModel_directory = app_classes_directory + "ProfilesViewModel\\";


### PR DESCRIPTION
## Summary
- Separate service and repository interfaces from implementations
- Support creation of new API class subdirectories during scaffolding

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt-update.log && tail -n 20 /tmp/apt-update.log` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a10df6b27c832cbcdc19f366ea2723