### PR TITLE
Improve export options for full result sets

### DIFF
--- a/CrudForms/Properties/AssemblyInfo.cs
+++ b/CrudForms/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.5.3.7")]
-[assembly: AssemblyFileVersion("5.5.3.7")]
+[assembly: AssemblyVersion("5.5.3.8")]
+[assembly: AssemblyFileVersion("5.5.3.8")]

--- a/CrudForms/Visao/UC_FormularioGenerico.cs
+++ b/CrudForms/Visao/UC_FormularioGenerico.cs
@@ -589,7 +589,28 @@ namespace Visao
                 return;
             }
 
-            if(Message.MensagemConfirmaçãoYesNo("Deseja criar arquivo com a exportação? Se precionar não será copiado para área de transferência!") == DialogResult.OK)
+            List<Regras.AcessoBancoCliente.AcessoBanco> valoresExportacao = this.valores;
+
+            if (this.tabela != null && this.quantidadeTotal > this.valores.Count)
+            {
+                if (Message.MensagemConfirmaçãoYesNo("Deseja exportar todos os registros encontrados? Caso selecione Não, somente os registros exibidos serão exportados.") == DialogResult.Yes)
+                {
+                    var instanciaBanco = Regras.AcessoBancoCliente.AcessoBanco.GetInstanciaBancoCliente();
+                    var filtroExportacao = this.filtro ?? new Model.Filtro();
+                    var todosValores = instanciaBanco.BuscaLista(this.tabela, this.colunas, filtroExportacao, 1, out _, out _, false);
+
+                    if (todosValores == null || todosValores.Count == 0)
+                    {
+                        Message.MensagemAlerta("Não foi possível recuperar todos os registros. A exportação continuará com os dados exibidos na tela.");
+                    }
+                    else
+                    {
+                        valoresExportacao = todosValores;
+                    }
+                }
+            }
+
+            if(Message.MensagemConfirmaçãoYesNo("Deseja criar arquivo com a exportação? Se precionar não será copiado para área de transferência!") == DialogResult.Yes)
             {
                 FolderBrowserDialog dialog = new FolderBrowserDialog();
                 dialog.Description = "Selecione onde deseja salvar o arquivo";
@@ -599,7 +620,7 @@ namespace Visao
                     string nomeArquivo = tabela != null ? this.tabela.DAO.Nome : "relatorio_generico";
 
 
-                    if (!Regras.GerarArquivoExportacao.GerarArquivo(tipo, this.valores, directory, nomeArquivo, out var mensagemErro))
+                    if (!Regras.GerarArquivoExportacao.GerarArquivo(tipo, valoresExportacao.ToList(), directory, nomeArquivo, out var mensagemErro))
                     {
                         Message.MensagemErro("Houve erros.");
                         Message.MensagemErro(mensagemErro);
@@ -612,7 +633,7 @@ namespace Visao
             }
             else
             {
-                if (!Regras.GerarArquivoExportacao.GerarRelatorioParaAreaTranferencia(tipo, this.valores, out var mensagemErro))
+                if (!Regras.GerarArquivoExportacao.GerarRelatorioParaAreaTranferencia(tipo, valoresExportacao.ToList(), out var mensagemErro))
                 {
                     Message.MensagemErro("Houve erros.");
                     Message.MensagemErro(mensagemErro);

--- a/Instalador/instalador.iss
+++ b/Instalador/instalador.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Crud Creator"
-#define MyAppVersion "5.5.3.7"
+#define MyAppVersion "5.5.3.8"
 #define MyAppPublisher "SunSale System"
 #define MyAppURL "http://www.sunsalesystem.com.br/"
 #define MyAppExeName "CrudForms.exe"


### PR DESCRIPTION
## Summary
- prompt users to export all matching records and fetch the complete dataset when requested
- fix the confirmation dialog so exporting to a file or clipboard honors the selected destination
- clone the export data before generating files or clipboard content to avoid mutating in-memory results

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eeb382f3fc832cacca9f14602fc50e